### PR TITLE
[4/n] Parser MCP loop

### DIFF
--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -1495,6 +1495,12 @@ def _parse_chat_message_content(
     role = message["role"]
     content = message.get("content")
     reasoning = message.get("reasoning") or message.get("reasoning_content")
+    # TODO: get from reasoning_content?
+
+    # HACK
+    if role == "tool":
+        content_format = "openai"
+
     if content is None:
         content = []
     elif isinstance(content, str):
@@ -1503,7 +1509,9 @@ def _parse_chat_message_content(
         role,
         content,  # type: ignore
         mm_tracker,
-        wrap_dicts=(content_format == "openai"),
+        wrap_dicts=(
+            content_format == "openai"
+        ),  # kimik2 thinks this is string, breaks on tool
         interleave_strings=interleave_strings,
     )
 

--- a/vllm/entrypoints/context.py
+++ b/vllm/entrypoints/context.py
@@ -239,24 +239,21 @@ class ParsableContext(ConversationContext):
         self.chat_template_content_format = chat_template_content_format
         self.tool_dicts = tool_dicts
 
-    def append_output(
-        self, output: RequestOutput | list[CustomChatCompletionMessageParam]
-    ) -> None:
+    def append_output(self, output: RequestOutput) -> None:
         self.last_output = output
-        if isinstance(output, RequestOutput):
-            self.num_prompt_tokens = len(output.prompt_token_ids or [])
-            self.num_cached_tokens = output.num_cached_tokens or 0
-            self.num_output_tokens += len(output.outputs[0].token_ids or [])
+        self.num_prompt_tokens = len(output.prompt_token_ids or [])
+        self.num_cached_tokens = output.num_cached_tokens or 0
+        self.num_output_tokens += len(output.outputs[0].token_ids or [])
 
-            # output_token_ids = output.outputs[0].token_ids
-            # for token_id in output_token_ids:
-            #     self.parser.process(token_id)
-            self.parser.process(output.outputs[0])
-        else:
-            self.parser.chat_completion_messages.extend(output)
+        # output_token_ids = output.outputs[0].token_ids
+        # for token_id in output_token_ids:
+        #     self.parser.process(token_id)
+        self.parser.process(output.outputs[0])
 
-    def append_tool_output(self, output) -> None:
-        raise NotImplementedError("Should not be called.")
+    def append_tool_output(
+        self, output: list[CustomChatCompletionMessageParam]
+    ) -> None:
+        self.parser.chat_completion_messages.extend(output)
 
     def need_builtin_tool_call(self) -> bool:
         """Return true if the last message is a MCP tool call"""

--- a/vllm/entrypoints/context.py
+++ b/vllm/entrypoints/context.py
@@ -263,7 +263,7 @@ class ParsableContext(ConversationContext):
         last_message = self.parser.chat_completion_messages[-1]["content"][-1]
         if isinstance(last_message, FunctionCall):
             # HACK: figure out which tools are MCP tools
-            if last_message.name == "code_interpreter":
+            if last_message.name == "code_interpreter" or last_message.name == "python":
                 return True
 
         return False
@@ -276,7 +276,7 @@ class ParsableContext(ConversationContext):
             return await tool_session.get_result(self)
         args = json.loads(last_msg.arguments)
         param = {
-            "code": args['code'],
+            "code": args["code"],
         }
         result = await tool_session.call_tool("python", param)
         result_str = result.content[0].text

--- a/vllm/entrypoints/openai/parser/parser.py
+++ b/vllm/entrypoints/openai/parser/parser.py
@@ -124,6 +124,9 @@ def get_streamable_parser_for_simple_context(
     )
 
 
+# def render_parser_for_completion():
+
+
 """
 TODO:
 how to figure out which tokens are special tokens

--- a/vllm/entrypoints/openai/parser/parser.py
+++ b/vllm/entrypoints/openai/parser/parser.py
@@ -54,10 +54,8 @@ class StreamableParser:
         pass
 
     def process(self, output: CompletionOutput) -> "StreamableParser":
-        reasoning_content, content = (
-            self.reasoning_parser_instance.extract_reasoning_content(
-                output.text, request=None
-            )
+        reasoning_content, content = self.reasoning_parser_instance.extract_reasoning(
+            output.text, request=None
         )
         if reasoning_content:
             new_content = ChatCompletionContentPartTextParam(

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -1334,7 +1334,9 @@ class OpenAIServing:
             # engine_prompt = EngineTokensPrompt(prompt_token_ids=prompt_token_ids)
             # request_prompt = prompt_token_ids
             # Update the sampling params.
-            sampling_params.max_tokens = self.max_model_len - len(engine_prompt)
+            sampling_params.max_tokens = self.max_model_len - len(
+                engine_prompt["prompt_token_ids"]
+            )
             # OPTIMIZATION
             priority = orig_priority - 1
 

--- a/vllm/entrypoints/openai/serving_responses.py
+++ b/vllm/entrypoints/openai/serving_responses.py
@@ -339,7 +339,7 @@ class OpenAIServingResponses(OpenAIServing):
         generators: list[AsyncGenerator[ConversationContext, None]] = []
 
         builtin_tool_list: list[str] = []
-        if self.use_harmony and self.tool_server is not None:
+        if self.tool_server is not None:
             if self.tool_server.has_tool("browser"):
                 builtin_tool_list.append("browser")
             if self.tool_server.has_tool("python"):
@@ -389,6 +389,7 @@ class OpenAIServingResponses(OpenAIServing):
                             reasoning_parser=self.reasoning_parser,
                             request=request,
                             tool_parser_cls=self.tool_parser,
+                            available_tools=available_tools,
                         )
                     else:
                         context = SimpleContext()


### PR DESCRIPTION
## Purpose
- parser manages tool parsing (non streaming)
- can do a MCP loop


## Test Plan

```
VLLM_USE_EXPERIMENTAL_PARSER_CONTEXT=1 vllm serve MiniMaxAI/MiniMax-M2   --tensor-parallel-size 4   --tool-call-parser minimax_m2   --reasoning-parser minimax_m2    --enable-auto-tool-choice --trust-remote-code --tool-server=localhost:8081/container,localhost:8081/browser,localhost:8081/python
```

function tool
```
curl http://localhost:8000/v1/responses   -H "Content-Type: application/json"   -N   -d '{
    "model": "MiniMaxAI/MiniMax-M2",
    "input": [
      {
        "role": "user",
        "content": "What is the weather in Paris in Celsius today?"
      }
    ],
    "tools": [{
        "type": "function",
        "name": "get_weather",
        "description": "Get the current weather in a given location",
        "parameters": {
            "type": "object",
            "properties": {
                "location": {"type": "string"},
                "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}
            },
            "required": ["location", "unit"]
        }
    }],
    "temperature": 0.7,
    "max_output_tokens": 2000
  }'

```

mcp tool
```
curl -X POST "http://localhost:8000/v1/responses"   -H "Content-Type: application/json"   -H "Authorization: Bearer dummy-api-key"   -d '{
        "model": "MiniMaxAI/MiniMax-M2",
        "input": "Multiply 64548*15151 using the python tool.",
        "tools": [
          {
            "type": "mcp",
            "server_label": "code_interpreter",
            "headers": {"test": "test"},
            "server_url": "IGNORED"
          }
        ]
      }'
```

## Test Result

MCP

```
{
    "id": "resp_e09f23e5a25d41f19917db4d17cd25bb",
    "created_at": 1762559699,
    "incomplete_details": null,
    "instructions": null,
    "metadata": null,
    "model": "MiniMaxAI/MiniMax-M2",
    "object": "response",
    "output": [
        {
            "id": "rs_88851126b65044f29dbd915193344075",
            "summary": [],
            "type": "reasoning",
            "content": [
                {
                    "text": "Okay, the user wants me to multiply two numbers, 64548 and 15151, using a Python tool. Looking at my available tools, I see I have a `code_interpreter` tool that can run Python code. This is perfect for this task.\n\nLet me think about how to approach this. The user has given me two integers to multiply, which is a straightforward arithmetic operation. I could certainly do this calculation mentally, but since the user specifically asked me to use the Python tool, I should use that.\n\nTo use the code_interpreter tool, I need to:\n1. Write a Python script that performs the multiplication\n2. Pass this script to the code_interpreter tool\n3. The tool will execute the script and return the result\n\nFor the Python script, I'll write a simple line that multiplies the two numbers:\n```python\nresult = 64548 * 15151\n```\n\nAnd then I should print the result so it's visible:\n```python\nprint(result)\n```\n\nI could combine these into a single line:\n```python\nprint(64548 * 15151)\n```\n\nBut keeping them as two separate lines might make it clearer what's happening in the code.\n\nLet me structure the tool call correctly. The code_interpreter tool requires a JSON object with the code to execute. So I'll format my request as:\n- tool name: \"code_interpreter\"\n- arguments: {\"code\": \"result = 64548 * 15151\\nprint(result)\"}\n\nThis should execute the Python code and return the product of 64548 and 15151. The multiplication of these two numbers will give us the final answer, which I can then provide to the user.\n",
                    "type": "reasoning_text"
                }
            ],
            "encrypted_content": null,
            "status": "completed"
        },
        {
            "id": "msg_91cb29d6ec5b4d65835156e1f452aa36",
            "content": [
                {
                    "annotations": [],
                    "text": "\n\n\n",
                    "type": "output_text",
                    "logprobs": null
                }
            ],
            "role": "assistant",
            "status": "completed",
            "type": "message"
        },
        {
            "arguments": "{\"code\": \"result = 64548 * 15151\\nprint(result)\"}",
            "call_id": "call_c4c9b8c5e6f84ded8bdf059c76607e2b",
            "name": "code_interpreter",
            "type": "function_call",
            "id": "fc_c28f846b7361458895f7c2503a7a6b65",
            "status": "completed"
        },
        {
            "id": "rs_eae56d29a97e4698a4b33cf55f2ac63b",
            "summary": [],
            "type": "reasoning",
            "content": [
                {
                    "text": "I need to analyze what happened in this conversation. The user asked me to multiply 64548 by 15151 using the Python tool. This is a straightforward arithmetic operation, but since they specifically requested using Python, I need to use the code_interpreter tool that I have available.\n\nLooking at my available tools, I can see I have access to a \"code_interpreter\" which can execute Python code. This is perfect for this multiplication task.\n\nI called the code_interpreter tool with a simple Python script:\n```python\nresult = 64548 * 15151\nprint(result)\n```\n\nThis script does two things:\n1. It calculates the product of 64548 and 15151 and stores it in a variable called \"result\"\n2. It prints the value of that variable to output the answer\n\nThe tool executed this code and returned \"977966748\" as the result. This is the product of multiplying 64548 by 15151, which is what the user requested.\n\nNow I need to provide this answer to the user in a clear and straightforward way. I don't need to include the Python code itself in my response since the user just wanted the result of the calculation. I'll simply state the answer directly: 977,966,748.\n\nI should format this number with commas for better readability, as large numbers are typically written with thousands separators. So I'll write it as \"977,966,748\" rather than \"977966748\".\n\nThe calculation is complete, and I have the correct answer to provide to the user.\n",
                    "type": "reasoning_text"
                }
            ],
            "encrypted_content": null,
            "status": "completed"
        },
        {
            "id": "msg_ae7f39c27bd34559a372adef918787b4",
            "content": [
                {
                    "annotations": [],
                    "text": "\n\nThe result of multiplying 64548 by 15151 is 977,966,748.",
                    "type": "output_text",
                    "logprobs": null
                }
            ],
            "role": "assistant",
            "status": "completed",
            "type": "message"
        }
    ],
    "parallel_tool_calls": true,
    "temperature": 1.0,
    "tool_choice": "auto",
    "tools": [
        {
            "server_label": "code_interpreter",
            "type": "mcp",
            "allowed_tools": null,
            "authorization": null,
            "connector_id": null,
            "headers": {
                "test": "test"
            },
            "require_approval": null,
            "server_description": null,
            "server_url": "IGNORED"
        }
    ],
    "top_p": 0.95,
    "background": false,
    "max_output_tokens": 196607,
    "max_tool_calls": null,
    "previous_response_id": null,
    "prompt": null,
    "reasoning": null,
    "service_tier": "auto",
    "status": "completed",
    "text": null,
    "top_logprobs": null,
    "truncation": "disabled",
    "usage": {
        "input_tokens": 614,
        "input_tokens_details": {
            "cached_tokens": 528,
            "input_tokens_per_turn": [],
            "cached_tokens_per_turn": []
        },
        "output_tokens": 715,
        "output_tokens_details": {
            "reasoning_tokens": 0,
            "tool_output_tokens": 0,
            "output_tokens_per_turn": [],
            "tool_output_tokens_per_turn": []
        },
        "total_tokens": 1329
    },
    "user": null,
    "input_messages": null,
    "output_messages": null
}
```
